### PR TITLE
Fixed bug when parsing extended tag length.

### DIFF
--- a/src/bacnet-analyzer.pac
+++ b/src/bacnet-analyzer.pac
@@ -56,13 +56,13 @@
     double get_double(const_bytestring data);
     string get_string(const_bytestring data);
 
-    string parse_tag(uint8 tag_num, uint8 tag_class, const_bytestring data, uint8 tag_length);
+    string parse_tag(uint8 tag_num, uint8 tag_class, const_bytestring data, uint32 tag_length);
 
     %}
 
 %code{
     // Parses Application Tag based on tag_num and returns string representation of data
-    string parse_tag(uint8 tag_num, uint8 tag_class, const_bytestring data, uint8 tag_length)
+    string parse_tag(uint8 tag_num, uint8 tag_class, const_bytestring data, uint32 tag_length)
     {
         string str = "";
         switch(tag_num){

--- a/src/bacnet-protocol.pac
+++ b/src/bacnet-protocol.pac
@@ -815,7 +815,7 @@ type BACnet_Tag = record {
         default -> tag_header >> 4;
     };
     tag_class:  uint8   = (tag_header >> 3) & 1;
-    tag_length: uint8   = case(tag_header & 0x07) of {
+    tag_length: uint32   = case(tag_header & 0x07) of {
         5             -> extended_length.length;
         OPENING       -> 0;
         CLOSING       -> 0;


### PR DESCRIPTION
There is a bug in the parsing the length field for an extended tag. It resulted in missing packet header entries in bacnet.log.

In bacnet-protocol.pac the extended_length.length variable can be a uint16 or a uint32. The tag_length field was declared as a uint8. In the event an extended tag had a longer value it was truncated to one byte, resulting in misparsing the tag and subsequent tags in the packet.

This change also required a couple of subsequent changes in bacnet-analyzer.pac.

I discovered the bug when looking at Atomic Write File traffic, specifically the write file in this pcap: http://kargs.net/captures/atomic-write-file.cap

After making the change this pcap and the other Atomic Write File and Atomic Read File pcaps on http://kargs.net/captures/ appear correctly in bacnet.log. Everything was done against Zeek 3.2.3 running in pcap mode.
