### PR TITLE
Fix a comparison that would cause an overflow error.

### DIFF
--- a/scripts/icsnpp/bacnet/main.zeek
+++ b/scripts/icsnpp/bacnet/main.zeek
@@ -117,7 +117,7 @@ event bacnet_header(c: connection,
     if (bvlc_function == 0)
         bacnet_log$result_code = bvlc_results[result_code];
 
-    if(pdu_type != -1){
+    if(pdu_type in apdu_types){
         bacnet_log$pdu_type = apdu_types[pdu_type];
 
         if (pdu_type != 1)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Line 120 in main.zeek would cause on overflow error because it compared a count to -1:

```
overflow promoting from unsigned/double to signed arithmetic value (int and 18446744073709551615)
```

This change instead checks to see if the value is in the table.

## 💭 Motivation and context ##

To fix an error showing up in reporter.log.

## 🧪 Testing ##

I didn't see any tests in this repo.  I saw the error on a busy network I monitor so I thought I'd supply this change to your repo.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X ] This PR has an informative and human-readable title.
- [X ] Changes are limited to a single goal - _eschew scope creep!_

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
