### PR TITLE
Handle case where bacnet property value is set to a non-numeric value

### DIFF
--- a/scripts/icsnpp/bacnet/main.zeek
+++ b/scripts/icsnpp/bacnet/main.zeek
@@ -312,35 +312,39 @@ event bacnet_read_property_ack(c: connection,
     if( property_array_index != UINT32_MAX )
         bacnet_property$array_index = property_array_index;
 
-    switch(property_identifier){
-        case 36:
-            bacnet_property$value = event_states[to_count(property_value)];
-            break;
-        case 72:
-            bacnet_property$value = notify_type[to_count(property_value)];
-            break;
-        case 79:
-            bacnet_property$value = object_types[to_count(property_value)];
-            break;
-        case 103:
-            bacnet_property$value = reliability[to_count(property_value)];
-            break;
-        case 107:
-            bacnet_property$value = segmentation_supported_status[to_count(property_value)];
-            break;
-        case 112:
-            bacnet_property$value = device_status[to_count(property_value)];
-            break;
-        case 117:
-            bacnet_property$value = bacnet_units[to_count(property_value)];
-            break;
-        case 197:
-            bacnet_property$value = logging_type[to_count(property_value)];
-            break;
-        default:
-            if (property_value != "")
-                bacnet_property$value = property_value;
-            break;
+    if (is_num(property_value)) {
+        switch(property_identifier){
+            case 36:
+                bacnet_property$value = event_states[to_count(property_value)];
+                break;
+            case 72:
+                bacnet_property$value = notify_type[to_count(property_value)];
+                break;
+            case 79:
+                bacnet_property$value = object_types[to_count(property_value)];
+                break;
+            case 103:
+                bacnet_property$value = reliability[to_count(property_value)];
+                break;
+            case 107:
+                bacnet_property$value = segmentation_supported_status[to_count(property_value)];
+                break;
+            case 112:
+                bacnet_property$value = device_status[to_count(property_value)];
+                break;
+            case 117:
+                bacnet_property$value = bacnet_units[to_count(property_value)];
+                break;
+            case 197:
+                bacnet_property$value = logging_type[to_count(property_value)];
+                break;
+            default:
+                if (property_value != "")
+                    bacnet_property$value = property_value;
+                break;
+        }
+    } else if (property_value != "") {
+        bacnet_property$value = property_value;
     }
 
     Log::write(LOG_BACNET_PROPERTY, bacnet_property);
@@ -371,35 +375,39 @@ event bacnet_write_property(c: connection,
     if( property_array_index != UINT32_MAX )
         bacnet_property$array_index = property_array_index;
 
-    switch(property_identifier){
-        case 36:
-            bacnet_property$value = event_states[to_count(property_value)];
-            break;
-        case 72:
-            bacnet_property$value = notify_type[to_count(property_value)];
-            break;
-        case 79:
-            bacnet_property$value = object_types[to_count(property_value)];
-            break;
-        case 103:
-            bacnet_property$value = reliability[to_count(property_value)];
-            break;
-        case 107:
-            bacnet_property$value = segmentation_supported_status[to_count(property_value)];
-            break;
-        case 112:
-            bacnet_property$value = device_status[to_count(property_value)];
-            break;
-        case 117:
-            bacnet_property$value = bacnet_units[to_count(property_value)];
-            break;
-        case 197:
-            bacnet_property$value = logging_type[to_count(property_value)];
-            break;
-        default:
-            if (property_value != "")
-                bacnet_property$value = property_value;
-            break;
+    if (is_num(property_value)) {
+        switch(property_identifier){
+            case 36:
+                bacnet_property$value = event_states[to_count(property_value)];
+                break;
+            case 72:
+                bacnet_property$value = notify_type[to_count(property_value)];
+                break;
+            case 79:
+                bacnet_property$value = object_types[to_count(property_value)];
+                break;
+            case 103:
+                bacnet_property$value = reliability[to_count(property_value)];
+                break;
+            case 107:
+                bacnet_property$value = segmentation_supported_status[to_count(property_value)];
+                break;
+            case 112:
+                bacnet_property$value = device_status[to_count(property_value)];
+                break;
+            case 117:
+                bacnet_property$value = bacnet_units[to_count(property_value)];
+                break;
+            case 197:
+                bacnet_property$value = logging_type[to_count(property_value)];
+                break;
+            default:
+                if (property_value != "")
+                    bacnet_property$value = property_value;
+                break;
+        }
+    } else if (property_value != "") {
+        bacnet_property$value = property_value;
     }
 
     Log::write(LOG_BACNET_PROPERTY, bacnet_property);


### PR DESCRIPTION
Handle case where bacnet property value is set to a non-numeric value (such as 'PropertyError') to prevent a to_count error on a string value

Signed-off-by: Seth Grover <mero.mero.guero@gmail.com>

There are some cases where a property_value may get passed into the Zeek side from the binpac side set to a string value like `PropertyError`. In `bacnet_write_property` and `bacnet_write_property` it will attempt to convert this to a `count` value using `to_count`, which will result in this error:

`bad conversion to count (to_count(Bacnet::property_value) and PropertyError)`

This fix double-checks to make sure the property_value is a numeric character before doing the lookup, otherwise it stores the string as-is.
