### PR TITLE
Add an empty string check because is_num("") == T.

### DIFF
--- a/scripts/icsnpp/bacnet/main.zeek
+++ b/scripts/icsnpp/bacnet/main.zeek
@@ -312,7 +312,7 @@ event bacnet_read_property_ack(c: connection,
     if( property_array_index != UINT32_MAX )
         bacnet_property$array_index = property_array_index;
 
-    if (is_num(property_value)) {
+    if (property_value != "" && is_num(property_value)) {
         switch(property_identifier){
             case 36:
                 bacnet_property$value = event_states[to_count(property_value)];

--- a/scripts/icsnpp/bacnet/main.zeek
+++ b/scripts/icsnpp/bacnet/main.zeek
@@ -375,7 +375,7 @@ event bacnet_write_property(c: connection,
     if( property_array_index != UINT32_MAX )
         bacnet_property$array_index = property_array_index;
 
-    if (is_num(property_value)) {
+    if (property_value != "" && is_num(property_value)) {
         switch(property_identifier){
             case 36:
                 bacnet_property$value = event_states[to_count(property_value)];


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

is_num("") evaluates to True, but for our cases it needs to be false because we do a to_count() later.

## 💭 Motivation and context ##

Because it was a bug in some pcaps I tested.

## 🧪 Testing ##

There were no tests for me to hook into.

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
