### PR TITLE
Add zeek/zeek-version.h include

### DIFF
--- a/src/BACNET.h
+++ b/src/BACNET.h
@@ -3,6 +3,12 @@
 #ifndef ANALYZER_PROTOCOL_BACNET_BACNET_H
 #define ANALYZER_PROTOCOL_BACNET_BACNET_H
 
+#if __has_include(<zeek/zeek-version.h>)
+#include <zeek/zeek-version.h>
+#else
+#include <zeek/zeek-config.h>
+#endif
+
 #include "events.bif.h"
 
 #if ZEEK_VERSION_NUMBER >= 40100


### PR DESCRIPTION
## 🗣 Description ##

I'd like to use this plugin for builtin-plugin integration testing within the Zeek CI pipeline (as an example of an external plugin using binpac). Due to zeek/zeek#2806 with the latest master version this requires an explicit `zeek/zeek-version.h` include.

That include is good practice anyway, so it'd be nice if that could be merged.

Reference zeek/zeek#2847.
 
## 💭 Motivation and context ##

See description.

## 🧪 Testing ##

* Compile testing when build into Zeek using `./configure --include-plugins=...`

## ✅ Pre-approval checklist ##

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
