### PR TITLE
update DPD signature for bacnet to that suggested by @keithjjones in …

### DIFF
--- a/scripts/icsnpp/bacnet/dpd.sig
+++ b/scripts/icsnpp/bacnet/dpd.sig
@@ -2,6 +2,6 @@ signature bacnet_dpd {
   ip-proto == udp
   src-port == 1024-65535
   dst-port == 1024-65535
-  payload /\x81\x0a..\x01/
+  payload /\x81[\x0a\x0b]..\x01/
   enable "bacnet"
 }

--- a/scripts/icsnpp/bacnet/dpd.sig
+++ b/scripts/icsnpp/bacnet/dpd.sig
@@ -1,5 +1,7 @@
 signature bacnet_dpd {
   ip-proto == udp
-  payload /\x81[\x00-x0b]/
+  src-port == 1024-65535
+  dst-port == 1024-65535
+  payload /\x81\x0a..\x01/
   enable "bacnet"
 }


### PR DESCRIPTION
update DPD signature for bacnet to that suggested by @keithjjones in cisagov/icsnpp-bacnet#21. he states 'This provides a DPD signature for Bacnet. I've been running this on several live networks for many months and have been happy with the results. It has uncovered several Bacnet networks I did not know about on non standard ports, which is pretty common for this protocol.'

resolves cisagov/icsnpp-bacnet#21