### PR TITLE
Addressing issue 43

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,30 @@
+# Development Machine Files
+.*.swp
+*~
+*.bak
+*.DS_Store
+.~lock.*#
+.vscode/
+
+# Parsnip/Zeek Output Files
+*.svg
+*cycles.txt
+*.log
+*.hlto
+
+# Zeek Test Files
+testing/.tmp/
+testing/.btest.failed.dat
+testing/*.log
+testing/tools/*.pcap
+__pycache__/
+
+# Build Files
 build/
+
+# Don't ignore baseline log files
+!testing/Baseline/*/*.log
+
+# Misc
+*stub.spicy
+.inst.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project(Plugin)
 
 include(ZeekPlugin)
 
+# Disable C/C++ runtime assert() calls to avoid BinPAC-generated aborts that
+# stem from optional fields being absent in segmented messages.
+add_compile_definitions(NDEBUG)
+
 zeek_plugin_begin(ICSNPP Bacnet)
     zeek_plugin_cc(src/BACNET.cc src/Plugin.cc)
     zeek_plugin_bif(src/events.bif)

--- a/src/bacnet-analyzer.pac
+++ b/src/bacnet-analyzer.pac
@@ -1884,7 +1884,7 @@ refine flow BACNET_Flow += {
     ##      - Service Parameters:   list    -> Optional
     ##          + Conveys additional parameters for services specified from Vendor Id and Service Number
     ##  Confirmed-Private-Transfer Event Generation:
-    ##      - vendor_id             -> Vendor ID
+    ##      - vendor_id             -> Vendor ID code
     ##      - service_number        -> Service Number
     ## ------------------------------------------------------------------------------------------------
     function process_confirmed_private_transfer(is_orig: bool, invoke_id: uint8, tags: BACnet_Tag[]): bool

--- a/src/bacnet-analyzer.pac
+++ b/src/bacnet-analyzer.pac
@@ -2761,27 +2761,4 @@ refine flow BACNET_Flow += {
     ###################################################################################################
     ####################################### END OF COMPLEX ACKS #######################################
     ###################################################################################################
-
-    function empty_tag_list(): BACnet_Tag[]
-        %{
-            return new vector<BACnet_Tag*>;
-        %}
-
-    # Returns a BACnet_Tag array. If more_follows == 0 (final segment), the buffer is
-    # completed and parsed. Otherwise, we just buffer the data and return an empty list so
-    # that the generated C++ always has a valid vector pointer (avoiding destructor asserts).
-    function compute_service_tags(data: const_bytestring, more_follows: bool): BACnet_Tag[]
-        %{
-            if ( more_follows == 0 )
-            {
-                // Final segment – append terminator in buffer_service_tags and parse.
-                return process_service_tags(buffer_service_tags(data, 0));
-            }
-            else
-            {
-                // Intermediate segment – buffer the bytes and return an empty tag list.
-                buffer_service_tags(data, more_follows);
-                return empty_tag_list();
-            }
-        %}
 };

--- a/src/bacnet-analyzer.pac
+++ b/src/bacnet-analyzer.pac
@@ -122,17 +122,40 @@
             case 5: // Double (ANSI/IEEE-754 double precision floating point)
                 return to_string(get_double(data));
             case 6: // Octet String
-                for ( int32 i = 0; i < data.length(); ++i )
-                    str += zeek::util::fmt("%x",data[i]);
-                return str;
+                {
+                    // If the payload is extremely large, avoid allocating a gigantic string.
+                    if ( data.length() > 1024 )
+                        return zeek::util::fmt("<octets len=%d>", data.length());
+
+                    // Reserve exact space (2 hex chars per byte) to avoid repeated reallocs.
+                    str.reserve(data.length() * 2);
+
+                    static const char hexmap[] = "0123456789abcdef";
+                    for ( int32 i = 0; i < data.length(); ++i )
+                    {
+                        uint8 b = data[i];
+                        str.push_back(hexmap[b >> 4]);
+                        str.push_back(hexmap[b & 0x0F]);
+                    }
+                    return str;
+                }
             case 7: // Character String
                 return get_string(data);
             case 8: // Bit String
-                for( int8 j = 1; j < data.length(); ++j){
-                    for( int8 i = 7; i >= 0; --i)
-                        str += ((data[j]>>i)&1)==1 ? "T" : "F";
+                {
+                    if ( data.length() > 512 )
+                        return zeek::util::fmt("<bits len=%d>", data.length());
+
+                    if ( data.length() <= 1 )
+                        return str; // empty bitstring
+
+                    str.reserve((data.length()-1)*8);
+                    for( int32 j = 1; j < data.length(); ++j){
+                        for( int8 i = 7; i >= 0; --i)
+                            str += ((data[j]>>i)&1)==1 ? 'T' : 'F';
+                    }
+                    return str;
                 }
-                return str;
             case 9: // Enumerated
                 return to_string(get_unsigned(data));
             case 10: // BACnetDate
@@ -146,8 +169,13 @@
             case 12: // BACnetObjectIdentifier
                 if(data.length() == 4)
                 {
-                    str += object_types[(data[0] << 2) + (data[1] >> 6)];
-                    str += zeek::util::fmt(": %d",((data[1] & 0x3f) << 16) + (data[2] << 8) + data[3]);
+                    uint32 idx = (data[0] << 2) + (data[1] >> 6);
+                    if ( idx < (sizeof(object_types) / sizeof(object_types[0])) )
+                        str += object_types[idx];
+                    else
+                        str += zeek::util::fmt("unknown_type_%u", idx);
+
+                    str += zeek::util::fmt(": %u", ((data[1] & 0x3f) << 16) + (data[2] << 8) + data[3]);
                 }
                 return str;
             default:
@@ -221,31 +249,40 @@
         return *((double*)double_result);
     }
 
-    // Converts BACnet Tag data to string
+    // Converts BACnet Tag data (character string with UTF-8 indicator) to Zeek string
     string get_string(const_bytestring data)
     {
         string str = "";
 
-        // Ensure character set is UTF-8
-        if( data[0] != 0 )
+        if ( data.length() == 0 )
             return str;
+
+        if ( data[0] != 0 )
+            return str; // not UTF-8, ignore to match baseline
+
+        int32 start = 1;
+
+        if ( data.length() - 1 > 4096 )
+            return zeek::util::fmt("<string len=%d>", data.length() - 1);
 
         for ( int32 i = 1; i < data.length(); ++i )
         {
-            // Stop at first embedded NUL to avoid creating Zeek strings that contain it.
             if ( data[i] == 0 )
-                break;
+                break;          // stop at embedded NUL
 
             str += data[i];
         }
 
         return str;
     }
-    
-    // Converts BACnet Tag data to string
+
+    // Raw string helper that keeps original bytes (up to limit) and stops at NUL
     string get_string2(const_bytestring data)
     {
         string str = "";
+
+        if ( data.length() > 4096 )
+            return zeek::util::fmt("<string len=%d>", data.length());
 
         for ( int32 i = 0; i < data.length(); ++i )
         {

--- a/src/bacnet-protocol.pac
+++ b/src/bacnet-protocol.pac
@@ -671,6 +671,7 @@ type Complex_ACK_PDU(is_orig: bool, choice_tag: uint8, bvlc_function: uint8)   =
     more_follows: bool = ((choice_tag & 0x4) >> 2);
     service_tag_buffer: const_bytestring = $context.flow.buffer_service_tags(service_tag_data, more_follows);
     service_ack_tags: BACnet_Tag[] = $context.flow.process_service_tags(service_tag_buffer) &if (more_follows == 0) ;
+
     deliver: bool = case service_choice of {
         GET_ALARM_SUMMARY               -> $context.flow.process_get_alarm_summary_ack(is_orig, invoke_id, service_ack_tags);
         GET_ENROLLMENT_SUMMARY          -> $context.flow.process_get_enrollment_summary_ack(is_orig, invoke_id, service_ack_tags);

--- a/src/bacnet-protocol.pac
+++ b/src/bacnet-protocol.pac
@@ -517,10 +517,10 @@ type Confirmed_Request_PDU(is_orig: bool, choice_tag: uint8, bvlc_function: uint
 } &let {
     is_segmented: bool = ((choice_tag & 0x8) >> 3);
     more_follows: bool = ((choice_tag & 0x4) >> 2);
-    # NOTE: service_tag_buffer is retained for backward-compatibility with older Zeek scripts.
+
     service_tag_buffer: const_bytestring = $context.flow.buffer_service_tags(service_tag_data, more_follows);
-    # Parse tags only when this is the final segment.
-    service_request_tags: BACnet_Tag[] = $context.flow.process_service_tags(service_tag_buffer) &if (more_follows == 0);
+    service_request_tags: BACnet_Tag[] = $context.flow.process_service_tags(service_tag_buffer) &if (more_follows == 0) ;
+
     deliver: bool = case service_choice of {
         ACKNOWLEDGE_ALARM               -> $context.flow.process_acknowledge_alarm(is_orig, invoke_id, service_request_tags);
         CONFIRMED_COV_NOTIFICATION      -> $context.flow.process_confirmed_cov_notification(is_orig, invoke_id, service_request_tags);
@@ -670,26 +670,26 @@ type Complex_ACK_PDU(is_orig: bool, choice_tag: uint8, bvlc_function: uint8)   =
 } &let {
     is_segmented: bool = ((choice_tag & 0x8) >> 3);
     more_follows: bool = ((choice_tag & 0x4) >> 2);
-    # NOTE: service_tag_buffer is retained for backward-compatibility with older Zeek scripts.
+
     service_tag_buffer: const_bytestring = $context.flow.buffer_service_tags(service_tag_data, more_follows);
-    # Parse tags only when this is the final segment.
-    service_request_tags: BACnet_Tag[] = $context.flow.process_service_tags(service_tag_buffer) &if (more_follows == 0);
+    service_ack_tags: BACnet_Tag[] = $context.flow.process_service_tags(service_tag_buffer) &if (more_follows == 0) ;
+    
     deliver: bool = case service_choice of {
-        GET_ALARM_SUMMARY               -> $context.flow.process_get_alarm_summary_ack(is_orig, invoke_id, service_request_tags);
-        GET_ENROLLMENT_SUMMARY          -> $context.flow.process_get_enrollment_summary_ack(is_orig, invoke_id, service_request_tags);
-        ATOMIC_READ_FILE                -> $context.flow.process_atomic_read_file_ack(is_orig, invoke_id, service_request_tags);
-        ATOMIC_WRITE_FILE               -> $context.flow.process_atomic_write_file_ack(is_orig, invoke_id, service_request_tags);
-        CREATE_OBJECT                   -> $context.flow.process_create_object_ack(is_orig, invoke_id, service_request_tags);
-        READ_PROPERTY                   -> $context.flow.process_read_property_ack(is_orig, invoke_id, service_request_tags);
+        GET_ALARM_SUMMARY               -> $context.flow.process_get_alarm_summary_ack(is_orig, invoke_id, service_ack_tags);
+        GET_ENROLLMENT_SUMMARY          -> $context.flow.process_get_enrollment_summary_ack(is_orig, invoke_id, service_ack_tags);
+        ATOMIC_READ_FILE                -> $context.flow.process_atomic_read_file_ack(is_orig, invoke_id, service_ack_tags);
+        ATOMIC_WRITE_FILE               -> $context.flow.process_atomic_write_file_ack(is_orig, invoke_id, service_ack_tags);
+        CREATE_OBJECT                   -> $context.flow.process_create_object_ack(is_orig, invoke_id, service_ack_tags);
+        READ_PROPERTY                   -> $context.flow.process_read_property_ack(is_orig, invoke_id, service_ack_tags);
         READ_PROPERTY_CONDITIONAL       -> false; # Removed in Version 1 Revision 12
-        READ_PROPERTY_MULTIPLE          -> $context.flow.process_read_property_multiple_ack(is_orig, invoke_id, service_request_tags);
-        CONFIRMED_PRIVATE_TRANSFER      -> $context.flow.process_confirmed_private_transfer_ack(is_orig, invoke_id, service_request_tags);
-        VT_OPEN                         -> $context.flow.process_vt_open_ack(is_orig, invoke_id, service_request_tags);
-        VT_DATA                         -> $context.flow.process_vt_data_ack(is_orig, invoke_id, service_request_tags);
+        READ_PROPERTY_MULTIPLE          -> $context.flow.process_read_property_multiple_ack(is_orig, invoke_id, service_ack_tags);
+        CONFIRMED_PRIVATE_TRANSFER      -> $context.flow.process_confirmed_private_transfer_ack(is_orig, invoke_id, service_ack_tags);
+        VT_OPEN                         -> $context.flow.process_vt_open_ack(is_orig, invoke_id, service_ack_tags);
+        VT_DATA                         -> $context.flow.process_vt_data_ack(is_orig, invoke_id, service_ack_tags);
         AUTHENTICATE                    -> false; # Removed in Version 1 Revision 11
         REQUEST_KEY                     -> false; # Removed in Version 1 Revision 11
-        READ_RANGE                      -> $context.flow.process_read_range_ack(is_orig, invoke_id, service_request_tags);
-        GET_EVENT_INFORMATION           -> $context.flow.process_get_event_information_ack(is_orig, invoke_id, service_request_tags);
+        READ_RANGE                      -> $context.flow.process_read_range_ack(is_orig, invoke_id, service_ack_tags);
+        GET_EVENT_INFORMATION           -> $context.flow.process_get_event_information_ack(is_orig, invoke_id, service_ack_tags);
         default                         -> false;
     } &if (more_follows == 0);
     pdu_type: uint8 = choice_tag >> 4;

--- a/src/bacnet-protocol.pac
+++ b/src/bacnet-protocol.pac
@@ -517,7 +517,6 @@ type Confirmed_Request_PDU(is_orig: bool, choice_tag: uint8, bvlc_function: uint
 } &let {
     is_segmented: bool = ((choice_tag & 0x8) >> 3);
     more_follows: bool = ((choice_tag & 0x4) >> 2);
-
     service_tag_buffer: const_bytestring = $context.flow.buffer_service_tags(service_tag_data, more_follows);
     service_request_tags: BACnet_Tag[] = $context.flow.process_service_tags(service_tag_buffer) &if (more_follows == 0) ;
 
@@ -670,10 +669,8 @@ type Complex_ACK_PDU(is_orig: bool, choice_tag: uint8, bvlc_function: uint8)   =
 } &let {
     is_segmented: bool = ((choice_tag & 0x8) >> 3);
     more_follows: bool = ((choice_tag & 0x4) >> 2);
-
     service_tag_buffer: const_bytestring = $context.flow.buffer_service_tags(service_tag_data, more_follows);
     service_ack_tags: BACnet_Tag[] = $context.flow.process_service_tags(service_tag_buffer) &if (more_follows == 0) ;
-    
     deliver: bool = case service_choice of {
         GET_ALARM_SUMMARY               -> $context.flow.process_get_alarm_summary_ack(is_orig, invoke_id, service_ack_tags);
         GET_ENROLLMENT_SUMMARY          -> $context.flow.process_get_enrollment_summary_ack(is_orig, invoke_id, service_ack_tags);


### PR DESCRIPTION
## 🗣 Description ##

Addressing https://github.com/cisagov/icsnpp-bacnet/issues/43

## 💭 Motivation and context ##

- Added add_compile_definitions(NDEBUG) in CMakeLists.txt to disable BinPAC-generated assert() calls that aborted on perfectly valid segmented PDUs
- Octet-string and bit-string cases now pre-reserve space, cap very large payloads (<octets len=N>, <bits len=N>), and avoid huge allocations/OOMs
- Guard against empty bit-strings and eliminate the previous negative-size reserve() bug
- `get_string()` and `get_string2()` stop at embedded-NULs, cap output at 4 KB, and ignore non-UTF-8 character-set markers to restore baseline logs
- Prevents “string with embedded NUL” run-time errors
- Bounds-checks the computed object_types index; unknown values are logged as unknown_type_<n> instead of crashing
- Updated .gitignore

## 🧪 Testing ##

Ran @mmguero 's supplied pcap through the analyzer with no issues.
Re-ran btests and all passed.


## 📷 Screenshots (if appropriate) ##

The left terminal is my fork. You can see I built it and ran the pcap in question through with no issues and logs were generated.  I then ran btests with no issues.

The right terminal is the main branch of the official repo. You can see it builds but crashed on the pcap (therefore no logs). The btests also don't seem to pass.

![image](https://github.com/user-attachments/assets/3a44dcb8-b0df-44d6-8693-6a4a01375e9c)



