### PR TITLE
Align comment style with zeek comment style so docs generation works

### DIFF
--- a/scripts/icsnpp/bacnet/main.zeek
+++ b/scripts/icsnpp/bacnet/main.zeek
@@ -20,19 +20,19 @@ export {
     ################################  BACnet_Header -> bacnet.log  ################################
     ###############################################################################################
     type BACnet_Header: record {
-        ts                      : time      &log;   # Timestamp of event
-        uid                     : string    &log;   # Zeek unique ID for connection
-        id                      : conn_id   &log;   # Zeek connection struct (addresses and ports)
-        is_orig                 : bool      &log;   # the message came from the originator/client or the responder/server
-        source_h                : addr      &log;   # Source IP Address
-        source_p                : port      &log;   # Source Port
-        destination_h           : addr      &log;   # Destination IP Address
-        destination_p           : port      &log;   # Destination Port
-        bvlc_function           : string    &log;   # BVLC function (see bvlc_functions)
-        pdu_type                : string    &log;   # APDU type (see apdu_types)
-        pdu_service             : string    &log;   # APDU service (see unconfirmed_service_choice and confirmed_service_choice)
-        invoke_id               : count     &log;   # Invoke ID
-        result_code             : string    &log;   # See (abort_reasons, reject_reasons, and error_codes)
+        ts                      : time      &log;   ##< Timestamp of event
+        uid                     : string    &log;   ##< Zeek unique ID for connection
+        id                      : conn_id   &log;   ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool      &log;   ##< the message came from the originator/client or the responder/server
+        source_h                : addr      &log;   ##< Source IP Address
+        source_p                : port      &log;   ##< Source Port
+        destination_h           : addr      &log;   ##< Destination IP Address
+        destination_p           : port      &log;   ##< Destination Port
+        bvlc_function           : string    &log;   ##< BVLC function (see bvlc_functions)
+        pdu_type                : string    &log;   ##< APDU type (see apdu_types)
+        pdu_service             : string    &log;   ##< APDU service (see unconfirmed_service_choice and confirmed_service_choice)
+        invoke_id               : count     &log;   ##< Invoke ID
+        result_code             : string    &log;   ##< See (abort_reasons, reject_reasons, and error_codes)
     };
 
     global log_bacnet: event(rec: BACnet_Header);
@@ -41,22 +41,22 @@ export {
     ##################  Who-Is, I-Am, Who-Has, & I-Have -> bacnet_discovery.log  ##################
     ###############################################################################################
     type BACnet_Discovery: record {
-        ts                      : time      &log;   # Timestamp of event
-        uid                     : string    &log;   # Zeek unique ID for connection
-        id                      : conn_id   &log;   # Zeek connection struct (addresses and ports)
-        is_orig                 : bool      &log;   # the message came from the originator/client or the responder/server
-        source_h                : addr      &log;   # Source IP Address
-        source_p                : port      &log;   # Source Port
-        destination_h           : addr      &log;   # Destination IP Address
-        destination_p           : port      &log;   # Destination Port
-        pdu_service             : string    &log;   # who-is, i-am, who-has, or i-have
-        device_id_type          : string    &log;   # BACnetObjectIdentifier device (see object_types)
-        device_id_number        : count     &log;   # BACnetObjectIdentifier device instance number
-        object_type             : string    &log;   # BACnetObjectIdentifier object (see object_types)
-        instance_number         : count     &log;   # BACnetObjectIdentifier object instance number
-        vendor                  : string    &log;   # Vendor Name (i-am and i-have requests)
-        range                   : string    &log;   # Specify range of devices to return (in who-is and who-has requests)
-        object_name             : string    &log;   # Object name searching for (who-has) or responding with (i-have)
+        ts                      : time      &log;   ##< Timestamp of event
+        uid                     : string    &log;   ##< Zeek unique ID for connection
+        id                      : conn_id   &log;   ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool      &log;   ##< the message came from the originator/client or the responder/server
+        source_h                : addr      &log;   ##< Source IP Address
+        source_p                : port      &log;   ##< Source Port
+        destination_h           : addr      &log;   ##< Destination IP Address
+        destination_p           : port      &log;   ##< Destination Port
+        pdu_service             : string    &log;   ##< who-is, i-am, who-has, or i-have
+        device_id_type          : string    &log;   ##< BACnetObjectIdentifier device (see object_types)
+        device_id_number        : count     &log;   ##< BACnetObjectIdentifier device instance number
+        object_type             : string    &log;   ##< BACnetObjectIdentifier object (see object_types)
+        instance_number         : count     &log;   ##< BACnetObjectIdentifier object instance number
+        vendor                  : string    &log;   ##< Vendor Name (i-am and i-have requests)
+        range                   : string    &log;   ##< Specify range of devices to return (in who-is and who-has requests)
+        object_name             : string    &log;   ##< Object name searching for (who-has) or responding with (i-have)
     };
     global log_bacnet_discovery: event(rec: BACnet_Discovery);
 
@@ -64,21 +64,21 @@ export {
     ###################  Read-Property & Write-Property -> bacnet_property.log  ###################
     ###############################################################################################
     type BACnet_Property: record {
-        ts                      : time      &log;   # Timestamp of event
-        uid                     : string    &log;   # Zeek unique ID for connection
-        id                      : conn_id   &log;   # Zeek connection struct (addresses and ports)
-        is_orig                 : bool      &log;   # the message came from the originator/client or the responder/server
-        source_h                : addr      &log;   # Source IP Address
-        source_p                : port      &log;   # Source Port
-        destination_h           : addr      &log;   # Destination IP Address
-        destination_p           : port      &log;   # Destination Port
-        invoke_id               : count     &log;   # invoke ID for help matching requests/responses
-        pdu_service             : string    &log;   # read-property-request/ack, write-property-request
-        object_type             : string    &log;   # BACnetObjectIdentifier object (see object_types)
-        instance_number         : count     &log;   # BACnetObjectIdentifier instance number
-        property                : string    &log;   # Property type (see property_identifiers)
-        array_index             : count     &log;   # Array index of property
-        value                   : string    &log;   # Value of property
+        ts                      : time      &log;   ##< Timestamp of event
+        uid                     : string    &log;   ##< Zeek unique ID for connection
+        id                      : conn_id   &log;   ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool      &log;   ##< the message came from the originator/client or the responder/server
+        source_h                : addr      &log;   ##< Source IP Address
+        source_p                : port      &log;   ##< Source Port
+        destination_h           : addr      &log;   ##< Destination IP Address
+        destination_p           : port      &log;   ##< Destination Port
+        invoke_id               : count     &log;   ##< invoke ID for help matching requests/responses
+        pdu_service             : string    &log;   ##< read-property-request/ack, write-property-request
+        object_type             : string    &log;   ##< BACnetObjectIdentifier object (see object_types)
+        instance_number         : count     &log;   ##< BACnetObjectIdentifier instance number
+        property                : string    &log;   ##< Property type (see property_identifiers)
+        array_index             : count     &log;   ##< Array index of property
+        value                   : string    &log;   ##< Value of property
     };
     global log_bacnet_property: event(rec: BACnet_Property);
 
@@ -86,21 +86,21 @@ export {
     #########  Reinitialize-Device & Device-Communication-Control -> bacnet_property.log  #########
     ###############################################################################################
     type BACnet_Device_Control: record {
-        ts                      : time      &log;   # Timestamp of event
-        uid                     : string    &log;   # Zeek unique ID for connection
-        id                      : conn_id   &log;   # Zeek connection struct (addresses and ports)
-        is_orig                 : bool      &log;   # the message came from the originator/client or the responder/server
-        source_h                : addr      &log;   # Source IP Address
-        source_p                : port      &log;   # Source Port
-        destination_h           : addr      &log;   # Destination IP Address
-        destination_p           : port      &log;   # Destination Port
-        invoke_id               : count     &log;   # invoke ID for help matching requests/responses
-        pdu_service             : string    &log;   # reinitialize_device or device_communication_control
-        time_duration           : count     &log;   # number of minutes remote device should ignore other APDUs
-        device_state            : string    &log;   # state to put device into
-        password                : string    &log;   # password
-        result                  : string    &log;   # Success, Error, Reject, or Abort
-        result_code             : string    &log;   # resulting Error/Reject/Abort Code
+        ts                      : time      &log;   ##< Timestamp of event
+        uid                     : string    &log;   ##< Zeek unique ID for connection
+        id                      : conn_id   &log;   ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool      &log;   ##< the message came from the originator/client or the responder/server
+        source_h                : addr      &log;   ##< Source IP Address
+        source_p                : port      &log;   ##< Source Port
+        destination_h           : addr      &log;   ##< Destination IP Address
+        destination_p           : port      &log;   ##< Destination Port
+        invoke_id               : count     &log;   ##< invoke ID for help matching requests/responses
+        pdu_service             : string    &log;   ##< reinitialize_device or device_communication_control
+        time_duration           : count     &log;   ##< number of minutes remote device should ignore other APDUs
+        device_state            : string    &log;   ##< state to put device into
+        password                : string    &log;   ##< password
+        result                  : string    &log;   ##< Success, Error, Reject, or Abort
+        result_code             : string    &log;   ##< resulting Error/Reject/Abort Code
     };
     global log_bacnet_device_control: event(rec: BACnet_Device_Control);
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

When you do single line comments in Zeek, zeekygen expects ##< to signal where they apply, so changed single hashes to those.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Fixes automated documentation and schema generation.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
